### PR TITLE
Increase build performance

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -128,7 +128,9 @@ allprojects {
     }
     normalization {
         runtimeClasspath {
-            ignore '**/application.properties'
+            properties {
+                ignoreProperty 'version.date'
+            }
             ignore '**/views.properties'
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -126,6 +126,12 @@ allprojects {
         exclude group: 'ch.qos.logback', module: 'logback-classic'
         exclude group: 'ch.qos.logback', module: 'logback-core'
     }
+    normalization {
+        runtimeClasspath {
+            ignore '**/application.properties'
+            ignore '**/views.properties'
+        }
+    }
 }
 
 /**
@@ -140,7 +146,7 @@ subprojects {
 
 def buildConf  = new org.yaml.snakeyaml.Yaml().load( file('./build.yaml').newDataInputStream() )
 project(':rundeckapp') {
-    it.ext.bundledPlugins = buildConf.rundeck.plugins
+    it.ext.bundledPlugins = buildConf?.rundeck?.plugins?:[]
 
     it.ext.bundledPlugins += [
         project(':plugins:script-plugin'),

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -94,7 +94,7 @@ dependencies {
       exclude group:'commons-codec', module: 'commons-codec'
       exclude group:'org.apache.httpcomponents', module: 'httpcore'
     }
-    
+
     implementation ("org.apache.httpcomponents:httpcore:4.4.15")
 
     compileOnly "org.projectlombok:lombok:1.18.20"
@@ -156,22 +156,15 @@ jar.doFirst {
     }
 }
 
-task expandTemplate {
-    inputs.file "$projectDir/src/main/meta/com/dtolabs/rundeck/core/application.properties"
-    outputs.file "$projectDir/src/main/resources/META-INF/com/dtolabs/rundeck/core/application.properties"
-
-    doLast {
-        ant.delete(file: "$projectDir/src/main/resources/META-INF/com/dtolabs/rundeck/core/application.properties")
-        def datestring = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssX").format(new Date())
-        println("Building: $version-$buildNum ($datestring)")
-        copy {
-            expand('version': version, 'version_build': buildNum, 'version_ident': version + '-' + buildNum, date: datestring)
-            from "$projectDir/src/main/meta/com/dtolabs/rundeck/core/application.properties"
-            into "$projectDir/src/main/resources/META-INF/com/dtolabs/rundeck/core/"
-        }
-    }
+def expandTemplate = tasks.register('expandTemplate', Copy) {
+    def dateString = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssX").format(new Date())
+    expand('version': version, 'version_build': buildNum, 'version_ident': version + '-' + buildNum, date: dateString)
+    from layout.projectDirectory.file('src/main/meta/com/dtolabs/rundeck/core/application.properties')
+    into layout.projectDirectory.file('src/main/resources/META-INF/com/dtolabs/rundeck/core')
 }
+
 processResources.dependsOn tasks.expandTemplate
+sourcesJar.dependsOn tasks.expandTemplate
 
 test{
     systemProperties 'rdeck.base': "$projectDir/build/rdeck_base"

--- a/gradle/exported-project.gradle
+++ b/gradle/exported-project.gradle
@@ -117,8 +117,3 @@ if (project.hasProperty('signing.keyId') && project.hasProperty('signing.passwor
 }
 
 
-java {
-    withJavadocJar()
-    withSourcesJar()
-}
-

--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -34,18 +34,6 @@ task testJar(type: Jar) {
     from sourceSets.test.java
 }
 
-// produce a jar file for our source files
-task sourceJar(type: Jar) {
-    classifier = 'sources'
-    from sourceSets.main.java
-}
-
-// produce a jar file for our javadoc
-task javadocJar(type: Jar, dependsOn: javadoc) {
-    classifier = 'javadoc'
-    from javadoc.destinationDir
-}
-
 if (JavaVersion.current().isJava8Compatible()) {
     tasks.withType(Javadoc) {
         options.addStringOption('Xdoclint:none', '-quiet')
@@ -55,6 +43,9 @@ if (JavaVersion.current().isJava8Compatible()) {
 // add all of the artifacts above to our archives list
 artifacts {
     archives testJar
-    archives sourceJar
-    archives javadocJar
+}
+
+java {
+    withJavadocJar()
+    withSourcesJar()
 }

--- a/grails-execution-mode-timer/build.gradle
+++ b/grails-execution-mode-timer/build.gradle
@@ -103,3 +103,7 @@ jar {
     enabled = true
     archiveClassifier = '' //use empty string
 }
+
+tasks.withType(org.grails.gradle.plugin.web.gsp.GroovyPageForkCompileTask).configureEach {
+    outputs.cacheIf { true }
+}

--- a/grails-metricsweb/build.gradle
+++ b/grails-metricsweb/build.gradle
@@ -94,3 +94,7 @@ tasks.withType(Test) {
 // enable if you wish to package this plugin as a standalone application
 bootJar.enabled = false
 bootRun.enabled = false
+
+tasks.withType(org.grails.gradle.plugin.web.gsp.GroovyPageForkCompileTask).configureEach {
+    outputs.cacheIf { true }
+}

--- a/grails-persistlocale/build.gradle
+++ b/grails-persistlocale/build.gradle
@@ -81,3 +81,7 @@ tasks.withType(Test) {
 
 // enable if you wish to package this plugin as a standalone application
 bootJar.enabled = false
+
+tasks.withType(org.grails.gradle.plugin.web.gsp.GroovyPageForkCompileTask).configureEach {
+    outputs.cacheIf { true }
+}

--- a/grails-repository/build.gradle
+++ b/grails-repository/build.gradle
@@ -103,3 +103,7 @@ tasks.withType(Test) {
 // enable if you wish to package this plugin as a standalone application
 bootJar.enabled = false
 bootRun.enabled = false
+
+tasks.withType(org.grails.gradle.plugin.web.gsp.GroovyPageForkCompileTask).configureEach {
+    outputs.cacheIf { true }
+}

--- a/grails-securityheaders/build.gradle
+++ b/grails-securityheaders/build.gradle
@@ -81,3 +81,7 @@ tasks.withType(Test) {
 
 // enable if you wish to package this plugin as a standalone application
 bootJar.enabled = false
+
+tasks.withType(org.grails.gradle.plugin.web.gsp.GroovyPageForkCompileTask).configureEach {
+    outputs.cacheIf { true }
+}

--- a/grails-webhooks/build.gradle
+++ b/grails-webhooks/build.gradle
@@ -92,3 +92,7 @@ gradle.beforeProject {
 assets {
     packagePlugin = true
 }
+
+tasks.withType(org.grails.gradle.plugin.web.gsp.GroovyPageForkCompileTask).configureEach {
+    outputs.cacheIf { true }
+}

--- a/rundeckapp/build.gradle
+++ b/rundeckapp/build.gradle
@@ -293,12 +293,8 @@ bootRun {
 }
 
 tasks.withType(GroovyCompile) {
-    def additionalSpecDir = new File(project.buildDir, 'openapi')
-    doFirst {
-        additionalSpecDir.mkdirs()
-    }
     configure(groovyOptions) {
-        forkOptions.jvmArgs = ['-Xmx1024m',"-Dmicronaut.openapi.additional.files=${additionalSpecDir.absolutePath}".toString()]
+        forkOptions.jvmArgs = ['-Xmx1024m']
     }
 }
 
@@ -342,53 +338,74 @@ buildProperties.doLast {
     }
 }
 
-task('copyPluginLibs').dependsOn(configurations.pluginFiles).doLast {
-    println "copying plugin libs"
-    File libextDir = new File(buildDir, "WEB-INF/rundeck/plugins")
-    File manifestFile = new File(buildDir, "WEB-INF/rundeck/plugins/manifest.properties")
+abstract class CreatePluginBundleTask extends DefaultTask {
+    @Input
+    abstract Property<String> getManifestName()
 
-    def filelist=[]
-    libextDir.mkdirs()
-    configurations.pluginFiles.files.each { pluginFile ->
-        project.logger.info("Bundling libExt plugin ${pluginFile.name}")
+    @Input
+    abstract Property<Configuration> getPluginConfig()
 
+    @OutputDirectory
+    abstract DirectoryProperty getDestinationDir()
 
-        copy {
-            from pluginFile
-            into libextDir
-        }
-        filelist << pluginFile.name
+    @TaskAction
+    def execute() {
+        File destDir = destinationDir.get().asFile.absoluteFile
+        File manifestFile = new File(destDir, manifestName.get())
 
-        /** Mangle JAR plugin properties **/
-        if ( ['.jar','.zip'].contains(pluginFile.name[-4..-1]) ) {
-            def pluginProps = [:]
-            pluginFile.withInputStream {
-                def jarmf = new JarInputStream(it).manifest
-                jarmf.getMainAttributes().findAll { it.key.toString().startsWith('Rundeck-Plugin') }.each { k, v ->
-                    pluginProps[k.toString()] = v
+        def fileList=[]
+        def artifacts = pluginConfig.get().incoming.artifacts
+        project.logger.info("Found ${artifacts.size()} artifacts")
+        artifacts.each { artifact ->
+            def pluginFile = artifact.file
+            project.logger.info("Bundling libExt plugin ${pluginFile.name}")
+            fileList << pluginFile.name
+
+            /** Mangle JAR plugin properties **/
+            if ( ['.jar','.zip'].contains(pluginFile.name[-4..-1]) ) {
+                def pluginProps = [:]
+                pluginFile.withInputStream {
+                    def jarmf = new JarInputStream(it).manifest
+                    jarmf.getMainAttributes().findAll { it.key.toString().startsWith('Rundeck-Plugin') }.each { k, v ->
+                        pluginProps[k.toString()] = v
+                    }
+                }
+                def f = pluginFile.name
+                Properties fileProps = new Properties()
+                fileProps['plugin.name'] = pluginProps['Rundeck-Plugin-Name'] ?: f
+                fileProps['plugin.description'] = pluginProps['Rundeck-Plugin-Description'] ?: 'Rundeck bundled plugin'
+                fileProps['plugin.author'] = pluginProps['Rundeck-Plugin-Author'] ?: 'Rundeck, Inc.'
+                fileProps['plugin.version'] = pluginProps['Rundeck-Plugin-File-Version'] ?: version
+                fileProps['plugin.url'] = pluginProps['Rundeck-Plugin-URL'] ?: 'http://rundeck.com'
+                fileProps['plugin.date'] = pluginProps['Rundeck-Plugin-BuildDate'] ?: (new Date().toString())
+                fileProps['plugin.filename'] = f
+
+                //write properties file
+                new File(destDir, pluginFile.name + '.properties').withOutputStream {
+                    fileProps.store(it, "generated manifest")
                 }
             }
-            def f = pluginFile.name
-            Properties fileProps = new Properties()
-            fileProps['plugin.name'] = pluginProps['Rundeck-Plugin-Name'] ?: f
-            fileProps['plugin.description'] = pluginProps['Rundeck-Plugin-Description'] ?: 'Rundeck bundled plugin'
-            fileProps['plugin.author'] = pluginProps['Rundeck-Plugin-Author'] ?: 'Rundeck, Inc.'
-            fileProps['plugin.version'] = pluginProps['Rundeck-Plugin-File-Version'] ?: version
-            fileProps['plugin.url'] = pluginProps['Rundeck-Plugin-URL'] ?: 'http://rundeck.com'
-            fileProps['plugin.date'] = pluginProps['Rundeck-Plugin-BuildDate'] ?: (new Date().toString())
-            fileProps['plugin.filename'] = f
-
-            //write properties file
-            new File(libextDir, pluginFile.name + '.properties').withOutputStream {
-                fileProps.store(it, "generated manifest")
-            }
+        }
+        Properties manifestProps = new Properties()
+        manifestProps['pluginFileList'] = (fileList.join(','))
+        manifestFile.withWriter { w ->
+            manifestProps.store(w,"generated manifest")
         }
     }
-    Properties manifestProps = new Properties()
-    manifestProps['pluginFileList'] = (filelist.join(','))
-    manifestFile.withWriter { w ->
-        manifestProps.store(w,"generated manifest")
-    }
+}
+
+def pluginPropertiesTask = tasks.register('createPluginProperties', CreatePluginBundleTask) {
+    dependsOn configurations.pluginFiles
+    destinationDir = file(layout.buildDirectory.dir("pluginProperties"))
+    manifestName = "manifest.properties"
+    pluginConfig = configurations.pluginFiles
+}
+
+tasks.register('copyPluginLibs', Copy) {
+    dependsOn createPluginProperties
+    from configurations.pluginFiles
+    from pluginPropertiesTask
+    into layout.buildDirectory.dir("WEB-INF/rundeck/plugins")
 }
 
 task copySpa(type: Copy) {
@@ -542,3 +559,12 @@ if (project.hasProperty('signing.keyId') && project.hasProperty('signing.passwor
     }
 }
 
+normalization {
+    runtimeClasspath {
+        ignore '**/grails.build.info'
+    }
+}
+
+tasks.withType(org.grails.gradle.plugin.web.gsp.GroovyPageForkCompileTask).configureEach {
+    outputs.cacheIf { true }
+}

--- a/rundeckapp/grails-spa/packages/ui-trellis/build.gradle
+++ b/rundeckapp/grails-spa/packages/ui-trellis/build.gradle
@@ -26,41 +26,41 @@ node{
     // If true, it will download node using above parameters
     // Note that npm is bundled with Node.js
     download = false
-
+    
     // Version of node to download and install (only used if download is true)
     // It will be unpacked in the workDir
     version = "v16.13.0"
-
+    
     // // Version of npm to use
     // // If specified, installs it in the npmWorkDir
     // // If empty, the plugin will use the npm command bundled with Node.js
     // npmVersion = ""
-
+    
     // // Version of Yarn to use
     // // Any Yarn task first installs Yarn in the yarnWorkDir
     // // It uses the specified version if defined and the latest version otherwise (by default)
     // yarnVersion = ""
-
+    
     // // Base URL for fetching node distributions
     // // Only used if download is true
     // // Change it if you want to use a mirror
     // // Or set to null if you want to add the repository on your own.
     // distBaseUrl = "https://nodejs.org/dist"
-
+    
     // // The npm command executed by the npmInstall task
     // // By default it is install but it can be changed to ci
     // npmInstallCommand = "install"
-
-
+    
+    
     // // The directory where npm is installed (when a specific version is defined)
     // npmWorkDir = file("${project.projectDir}/.gradle/npm")
-
-
+    
+    
     // // The Node.js project directory location
     // // This is where the package.json file and node_modules directory are located
     // // By default it is at the root of the current project
     // nodeProjectDir = file("${project.projectDir}")
-
+    
     // // Whether the plugin automatically should add the proxy configuration to npm and yarn commands
     // // according the proxy configuration defined for Gradle
     // // Disable this option if you want to configure the proxy for npm or yarn on your own

--- a/rundeckapp/grails-spa/packages/ui-trellis/build.gradle
+++ b/rundeckapp/grails-spa/packages/ui-trellis/build.gradle
@@ -26,41 +26,41 @@ node{
     // If true, it will download node using above parameters
     // Note that npm is bundled with Node.js
     download = false
-    
+
     // Version of node to download and install (only used if download is true)
     // It will be unpacked in the workDir
     version = "v16.13.0"
-    
+
     // // Version of npm to use
     // // If specified, installs it in the npmWorkDir
     // // If empty, the plugin will use the npm command bundled with Node.js
     // npmVersion = ""
-    
+
     // // Version of Yarn to use
     // // Any Yarn task first installs Yarn in the yarnWorkDir
     // // It uses the specified version if defined and the latest version otherwise (by default)
     // yarnVersion = ""
-    
+
     // // Base URL for fetching node distributions
     // // Only used if download is true
     // // Change it if you want to use a mirror
     // // Or set to null if you want to add the repository on your own.
     // distBaseUrl = "https://nodejs.org/dist"
-    
+
     // // The npm command executed by the npmInstall task
     // // By default it is install but it can be changed to ci
     // npmInstallCommand = "install"
-    
-    
+
+
     // // The directory where npm is installed (when a specific version is defined)
     // npmWorkDir = file("${project.projectDir}/.gradle/npm")
-    
-    
+
+
     // // The Node.js project directory location
     // // This is where the package.json file and node_modules directory are located
     // // By default it is at the root of the current project
     // nodeProjectDir = file("${project.projectDir}")
-    
+
     // // Whether the plugin automatically should add the proxy configuration to npm and yarn commands
     // // according the proxy configuration defined for Gradle
     // // Disable this option if you want to configure the proxy for npm or yarn on your own
@@ -104,17 +104,17 @@ def runNpmVersion = tasks.register('runNpmVersion', NpmTask) {t ->
     t.outputs.dir 'build/pack-version'
     t.outputs.cacheIf {true}
 
-    args = [ 'version' ]
-
+    def versionValue = ''
     if (findProperty('environment')?:'development' == 'release') {
         if (project.vTag == 'GA')
-            args.add("${project.vNum}".toString())
+            versionValue = "${project.vNum}"
         else
-            args.add("${project.vNum}-${project.vTag}.${new Date().getTime()}".toString())
+            versionValue = "${project.vNum}-${project.vTag}"
     }
     else {
-        args.add("${project.vNum}-snapshot.${new Date().getTime()}".toString())
+        versionValue = "${project.vNum}-snapshot"
     }
+    args = [ 'version', versionValue ]
 
     /** Copy to staging location where we will modify it */
     t.doFirst {

--- a/settings.gradle
+++ b/settings.gradle
@@ -15,7 +15,7 @@
  */
 
  plugins {
-    id "com.gradle.enterprise" version "3.7.1"
+    id "com.gradle.enterprise" version "3.10.3"
 }
 
 include	'rundeck-storage',
@@ -51,3 +51,5 @@ include	'rundeck-storage',
     'grails-webhooks',
     'grails-execution-mode-timer',
     'docker'
+
+rootProject.name = 'rundeck'


### PR DESCRIPTION
Some changes help with the consistency of up-to-date
checks during the build process. Other changes help
with caching improvements based on normalizing the
detection of changes within the outputs of tasks.
The final category of changes helps with absolute
path changes so that remote caching is more effective.